### PR TITLE
double overwrite

### DIFF
--- a/vrt.sh
+++ b/vrt.sh
@@ -37,7 +37,7 @@ DATE=$(date "+%A %d/%m/%Y %H:%M:%S")
             /usr/bin/ogr2ogr \
                 -f Postgresql \
                 -overwrite \
-                PG:"active_schema=${ACTIVESCHEMA}" "${vrt}" -lco GEOMETRY_NAME=geometry -nlt PROMOTE_TO_MULTI  -lco DESCRIPTION="import par ${JOB_NAME}/${BUILD_NUMBER} le ${DATE} - ${SOURCEDIR}/${vrt}"
+                PG:"active_schema=${ACTIVESCHEMA}" "${vrt}" -lco OVERWRITE=yes -lco GEOMETRY_NAME=geometry -nlt PROMOTE_TO_MULTI  -lco DESCRIPTION="import par ${JOB_NAME}/${BUILD_NUMBER} le ${DATE} - ${SOURCEDIR}/${vrt}"
             # post import sql
             if [ -f "${vrt}.sql" ]; then
                 echo "script sql après import trouvé"


### PR DESCRIPTION
Add a second overwrite for fixing the issue:
```
│ import de /home/app/apache-nas/vrts/irve_geojson_srs.vrt dans le schema public de la base prod_vrt_bot                                                                                     │
│ ERROR 1: Layer 7eee8f09_5d1b_4f48_a304_5e99e8da1e26 already exists, CreateLayer failed.                                                                                                    │
│ Use the layer creation option OVERWRITE=YES to replace it.                                                                                                                                 │
│ ERROR 1: Terminating translation prematurely after failed                                                                                                                                  │
│ translation of layer 7eee8f09-5d1b-4f48-a304-5e99e8da1e26 (use -skipfailures to skip errors) 
```